### PR TITLE
Docs vibe system

### DIFF
--- a/JupyterNotebooks/vtoolbox Demos.ipynb
+++ b/JupyterNotebooks/vtoolbox Demos.ipynb
@@ -21,7 +21,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [
     {
@@ -500,7 +500,9 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -513,7 +515,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 3.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -525,9 +527,9 @@
   "latex_envs": {
    "bibliofile": "biblio.bib",
    "cite_by": "apalike",
-   "current_citInitial": 1,
+   "current_citInitial": 1.0,
    "eqLabelWithNumbers": true,
-   "eqNumInitial": 0
+   "eqNumInitial": 0.0
   },
   "widgets": {
    "state": {
@@ -615,7 +617,7 @@
     "b9bba263ef3b4cc39d7a6388f6d1803b": {
      "views": [
       {
-       "cell_index": 12
+       "cell_index": 12.0
       }
      ]
     },
@@ -643,7 +645,7 @@
     "d795580e1b274cad98707cbbf7300005": {
      "views": [
       {
-       "cell_index": 10
+       "cell_index": 10.0
       }
      ]
     },

--- a/vibration_toolbox/vibesystem.py
+++ b/vibration_toolbox/vibesystem.py
@@ -313,8 +313,8 @@ class VibeSystem(object):
         >>> print(np.array_str(magdb[0, 1, :4], precision=2)) 
         [-69.54 -69.54 -69.54 -69.54]
         >>> # phase for output on 1 and input on 1.
-        >>> print(np.array_str(phase[1, 1, :4], precision=2, suppress_small=True)) 
-        [ -4.37e-16  -4.71e-03  -9.42e-03  -1.41e-02]
+        >>> print(np.array_str(phase[1, 1, :4], precision=5, suppress_small=True)) 
+        [-0.      -0.00471 -0.00942 -0.01413]
         """
         rows = self.H.inputs  # inputs (mag and phase)
         cols = self.H.inputs  # outputs

--- a/vibration_toolbox/vibesystem.py
+++ b/vibration_toolbox/vibesystem.py
@@ -135,7 +135,7 @@ class VibeSystem(object):
         ...               [-c2, c2+c3]])
         >>> K = np.array([[k1+k2, -k2],
         ...               [-k2, k2+k3]])
-        >>> sys = VibeSystem(M, C, K) # create the system        >>> sys =  
+        >>> sys = VibeSystem(M, C, K) # create the system    
         >>> print(np.array_str(sys.A(), precision=2))
         [[  0.00e+00   0.00e+00   1.00e+00   0.00e+00]
          [  0.00e+00   0.00e+00   0.00e+00   1.00e+00]

--- a/vibration_toolbox/vibesystem.py
+++ b/vibration_toolbox/vibesystem.py
@@ -314,7 +314,7 @@ class VibeSystem(object):
         [-69.54 -69.54 -69.54 -69.54]
         >>> # phase for output on 1 and input on 1.
         >>> print(np.array_str(phase[1, 1, :4], precision=5, suppress_small=True)) 
-        [-0.      -0.00471 -0.00942 -0.01413]
+        [...0.      -0.00471 -0.00942 -0.01413] 
         """
         rows = self.H.inputs  # inputs (mag and phase)
         cols = self.H.inputs  # outputs

--- a/vibration_toolbox/vibesystem.py
+++ b/vibration_toolbox/vibesystem.py
@@ -114,7 +114,35 @@ class VibeSystem(object):
 
     def A(self):
         """State space matrix
+        
+        This method will return the state space matrix
+        of the system.
+        
+        Returns
+        ----------
+        A : array
+            System's state space matrix. 
+
+        Examples
+        --------
+        >>> m1, m2 = 1, 1
+        >>> c1, c2, c3 = 1, 1, 1
+        >>> k1, k2, k3 = 1e3, 1e3, 1e3
+
+        >>> M = np.array([[m1, 0],
+        ...               [0, m2]])
+        >>> C = np.array([[c1+c2, -c2],
+        ...               [-c2, c2+c3]])
+        >>> K = np.array([[k1+k2, -k2],
+        ...               [-k2, k2+k3]])
+        >>> sys = VibeSystem(M, C, K) # create the system        >>> sys =  
+        >>> print(np.array_str(sys.A(), precision=2))
+        [[  0.00e+00   0.00e+00   1.00e+00   0.00e+00]
+         [  0.00e+00   0.00e+00   0.00e+00   1.00e+00]
+         [ -2.00e+03   1.00e+03  -2.00e+00   1.00e+00]
+         [  1.00e+03  -2.00e+03   1.00e+00  -2.00e+00]]
         """
+
         Z = np.zeros((self.n, self.n))
         I = np.eye(self.n)
 
@@ -281,10 +309,10 @@ class VibeSystem(object):
         ...               [-k2, k2+k3]])
         >>> sys1 = VibeSystem(M, C, K) # create the system
         >>> omega, magdb, phase = sys1.freq_response()
-        >>> magdb[0, 1, :4] # magnitude for output on 0 and input on 1.
-        array([-69.54242509, -69.54234685, -69.54211212, -69.5417209 ])
-        >>> np.around(phase[1, 1, :4],5) # phase for output on 1 and input on 1.
-        array([...0.     , -0.00471, -0.00942, -0.01413])
+        >>> print(np.array_str(magdb[0, 1, :4], precision=2)) # magnitude for output on 0 and input on 1.
+        [-69.54 -69.54 -69.54 -69.54]
+        >>> print(np.array_str(phase[1, 1, :4], precision=2)) # phase for output on 1 and input on 1.
+        [ -4.37e-16  -4.71e-03  -9.42e-03  -1.41e-02]
         """
         rows = self.H.inputs  # inputs (mag and phase)
         cols = self.H.inputs  # outputs

--- a/vibration_toolbox/vibesystem.py
+++ b/vibration_toolbox/vibesystem.py
@@ -309,9 +309,11 @@ class VibeSystem(object):
         ...               [-k2, k2+k3]])
         >>> sys1 = VibeSystem(M, C, K) # create the system
         >>> omega, magdb, phase = sys1.freq_response()
-        >>> print(np.array_str(magdb[0, 1, :4], precision=2)) # magnitude for output on 0 and input on 1.
+        >>> # magnitude for output on 0 and input on 1.
+        >>> print(np.array_str(magdb[0, 1, :4], precision=2)) 
         [-69.54 -69.54 -69.54 -69.54]
-        >>> print(np.array_str(phase[1, 1, :4], precision=2)) # phase for output on 1 and input on 1.
+        >>> # phase for output on 1 and input on 1.
+        >>> print(np.array_str(phase[1, 1, :4], precision=2, suppress_small=True)) 
         [ -4.37e-16  -4.71e-03  -9.42e-03  -1.41e-02]
         """
         rows = self.H.inputs  # inputs (mag and phase)

--- a/vibration_toolbox/vibesystem.py
+++ b/vibration_toolbox/vibesystem.py
@@ -53,10 +53,10 @@ class VibeSystem(object):
         ...               [-c2, c2+c3]])
         >>> K = np.array([[k1+k2, -k2],
         ...               [-k2, k2+k3]])
-        >>> sys1 = VibeSystem(M, C, K)
-        >>> sys1.wn
+        >>> sys = VibeSystem(M, C, K)
+        >>> sys.wn
         array([ 5.03292121,  8.71727525])
-        >>> sys1.wd
+        >>> sys.wd
         array([ 5.03229206,  8.71400566])
         """
         self._M = M
@@ -136,11 +136,11 @@ class VibeSystem(object):
         >>> K = np.array([[k1+k2, -k2],
         ...               [-k2, k2+k3]])
         >>> sys = VibeSystem(M, C, K) # create the system    
-        >>> print(np.array_str(sys.A(), precision=2))
-        [[  0.00e+00   0.00e+00   1.00e+00   0.00e+00]
-         [  0.00e+00   0.00e+00   0.00e+00   1.00e+00]
-         [ -2.00e+03   1.00e+03  -2.00e+00   1.00e+00]
-         [  1.00e+03  -2.00e+03   1.00e+00  -2.00e+00]]
+        >>> print(np.array_str(sys.A(), precision=2, suppress_small=True))
+        [[    0.     0.     1.     0.]
+         [    0.     0.     0.     1.]
+         [-2000.  1000.    -2.     1.]
+         [ 1000. -2000.     1.    -2.]]
         """
 
         Z = np.zeros((self.n, self.n))
@@ -254,15 +254,17 @@ class VibeSystem(object):
         ...               [-c2, c2+c3]])
         >>> K = np.array([[k1+k2, -k2],
         ...               [-k2, k2+k3]])
-        >>> sys1 = VibeSystem(M, C, K) # create the system
+        >>> sys = VibeSystem(M, C, K) # create the system
         >>> t = np.linspace(0, 25, 1000) # time array
         >>> F2 = np.zeros((len(t), 2))
         >>> F2[:, 1] = 1000*np.sin(40*t) # force applied on m2
-        >>> t, yout, xout = sys1.time_response(F2, t)
-        >>> yout[:5, 0] # response on m1
-        array([ 0.        ,  0.00304585,  0.07034816,  0.32048951,  0.60748282])
-        >>> yout[:5, 1] # response on m2
-        array([ 0.        ,  0.08160348,  0.46442657,  0.7885541 ,  0.47808092])
+        >>> t, yout, xout = sys.time_response(F2, t)
+        >>> # response on m1
+        >>> print(np.array_str(yout[:5, 0], precision=3)) 
+        [ 0.     0.003  0.07   0.32   0.607]
+        >>> # response on m2 
+        >>> print(np.array_str(yout[:5, 1], precision=3))
+        [ 0.     0.082  0.464  0.789  0.478]
         """
         if ic is not None:
             return signal.lsim(self.H, F, t, ic)
@@ -307,8 +309,8 @@ class VibeSystem(object):
         ...               [-c2, c2+c3]])
         >>> K = np.array([[k1+k2, -k2],
         ...               [-k2, k2+k3]])
-        >>> sys1 = VibeSystem(M, C, K) # create the system
-        >>> omega, magdb, phase = sys1.freq_response()
+        >>> sys = VibeSystem(M, C, K) # create the system
+        >>> omega, magdb, phase = sys.freq_response()
         >>> # magnitude for output on 0 and input on 1.
         >>> print(np.array_str(magdb[0, 1, :4], precision=2)) 
         [-69.54 -69.54 -69.54 -69.54]


### PR DESCRIPTION
Trying a different method to print arrays on examples. This approach seems to give more clear arrays on the output and helps to avoid error in the doctests.

As an example, for the .A() method for the vibesystem, the output was something like:

```
[[  0.00000000e+00   0.00000000e+00   0.00000000e+00   1.00000000e+00
    0.00000000e+00   0.00000000e+00]
 [  0.00000000e+00   0.00000000e+00   0.00000000e+00   0.00000000e+00
    1.00000000e+00   0.00000000e+00]
 [  0.00000000e+00   0.00000000e+00   0.00000000e+00   0.00000000e+00
    0.00000000e+00   1.00000000e+00]
 [ -3.20000000e+03   1.60000000e+03   0.00000000e+00  -6.40200000e+01
    3.20000000e+01   0.00000000e+00]
 [  1.60000000e+03  -3.20000000e+03   1.60000000e+03   3.20000000e+01
   -6.40200000e+01   3.20000000e+01]
 [  0.00000000e+00   1.60000000e+03  -1.60000000e+03   0.00000000e+00
    3.20000000e+01  -3.20200000e+01]]

```
Using `>>> print(np.array_str(sys.A(), precision=2, suppress_small=True))`:

```
[[    0.       0.       0.       1.       0.       0.  ]
 [    0.       0.       0.       0.       1.       0.  ]
 [    0.       0.       0.       0.       0.       1.  ]
 [-3200.    1600.       0.     -64.02    32.       0.  ]
 [ 1600.   -3200.    1600.      32.     -64.02    32.  ]
 [    0.    1600.   -1600.       0.      32.     -32.02]]
```

The command for the example is longer, but I think the final result is better. And I think the user will realize that this command is being used just for printing purposes on the docstring.