### PR TITLE
Change the in_ipynb function to work on the jupyter notebook.

### DIFF
--- a/vibration_toolbox/sdof.py
+++ b/vibration_toolbox/sdof.py
@@ -15,13 +15,15 @@ except ImportError:
 
 def in_ipynb():
     try:
-        cfg = get_ipython().config
-        if cfg['IPKernelApp']['parent_appname'] == 'ipython-notebook':
+        shell = get_ipython().__class__.__name__
+        if shell == 'ZMQInteractiveShell':  # Jupyter notebook or qtconsole?
             return True
-        else:
+        elif shell == 'TerminalInteractiveShell':  # Terminal running IPython?
             return False
+        else:
+            return False  # Other type (?)
     except NameError:
-        return False
+        return False      # Probably standard Python interpreter
 
 
 mpl.rcParams['lines.linewidth'] = 2


### PR DESCRIPTION
I was trying to use the phase_plot_i function in the jupyter notebook but was getting:

`'phase_plot_i can only be used in an iPython notebook.'`

I saw here the code to check if we are executing the function in a notebook:
http://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook

It seems that the code we were using does not apply to more recent versions of jupyter notebook.

I have changed our code using the code provided in another answer.