### PR TITLE
Links to notebooks

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,7 @@ Table of Contents
    installation
    tutorial/index
    reference/index
-
-.. .. include:: ../readme.rst
+   download_tutorial
 
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,10 @@ Table of Contents
    installation
    tutorial/index
    reference/index
-   download_tutorial
 
+Download Tutorial Notebooks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   :download:`Single Degree of Freedom </tutorial/sdofnotebook.ipynb>`
 
 Indices and tables
 __________________

--- a/docs/tutorial/sdofnotebook.ipynb
+++ b/docs/tutorial/sdofnotebook.ipynb
@@ -8,6 +8,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Download This Notebook](http://vibrationtoolbox.github.io/vibration_toolbox/_build/hmtl/_downloads/sdofnotebook.ipynb)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {


### PR DESCRIPTION
Trying to add links to download the notebooks. See issue #49 
The links are added using to the main page using the :download: sphinx role at the main index file. 
The links added to the notebooks refer to the main page and are not automatically generated by sphinx.