### PR TITLE
Updating notebook link to work on gh page.

### DIFF
--- a/docs/tutorial/sdofnotebook.ipynb
+++ b/docs/tutorial/sdofnotebook.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Download This Notebook](http://vibrationtoolbox.github.io/vibration_toolbox/_build/hmtl/_downloads/sdofnotebook.ipynb)"
+    "[Download This Notebook](http://vibrationtoolbox.github.io/vibration_toolbox/_downloads/sdofnotebook.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
This is just correcting the notebook download link (inside the notebook).
The links need to refer to: http://vibrationtoolbox.github.io/vibration_toolbox/_downloads/....