### PR TITLE
Use plt.gca() if the ax is not given.

### DIFF
--- a/vibration_toolbox/ema.py
+++ b/vibration_toolbox/ema.py
@@ -129,7 +129,7 @@ def plot_fft(t, time_response, ax=None):
     <matplotlib.axes...
     """
     if ax is None:
-        _, ax = plt.subplots()
+        ax = plt.gca()
 
     Ts = t[1] - t[0]  # sampling interval
     Fs = 1 / Ts  # sampling rate


### PR DESCRIPTION
I think this is a more standard way to deal with the plots when ax is
not given during the function call.