### PR TITLE
Solves error due to float interpretation as integer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-    - "3.5"
+#    - "3.5"
     - "3.6"
 
 before_install:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -71,7 +71,7 @@ To contribute code we recommend you follow these steps:
 
 8. Run the doctests regularly when you make edits.
 
-   To run the doctests `<pytest https://docs.pytest.org/en/latest/>`_ is needed and can be installed with ``pip install -U pytest``.
+   To run the doctests, `pytest <https://docs.pytest.org/en/latest/>`_ is needed and can be installed with ``pip install -U pytest``.
 
    To run the tests from the shell you can `cd` to the project's root directory and type::
 

--- a/vibration_toolbox/ema.py
+++ b/vibration_toolbox/ema.py
@@ -124,7 +124,7 @@ def plot_fft(t, time_response, ax=None, **kwargs):
     >>> t = np.linspace(0, 10, 1000)
     >>> time_response = 2 * np.sin(40*t)
     >>> vtb.plot_fft(t, time_response)
-    <matplotlib.axes...
+    <AxesSubplot:title=...
 
     """
     if ax is None:

--- a/vibration_toolbox/sdof.py
+++ b/vibration_toolbox/sdof.py
@@ -189,7 +189,7 @@ def time_plot(m=10, c=1, k=100, x0=1, v0=-1, max_time=100):
                 r'$\lambda_2$ = %0.2f' %
                 (zeta * omega + omega * (zeta ** 2 - 1)))
     ax.legend()
-    # plt.show()
+    plt.show()
 
 
 def time_plot_i(max_time=(1.0, 100.0), x0=(-100, 100), v0=(-100, 100),
@@ -563,7 +563,7 @@ def steady_state_response(zs=0.1, rmin=0.0, rmax=2.0):
     """
     if not isinstance(zs, list):
         zs = [zs]
-    r = np.linspace(rmin, rmax, 100 * (rmax - rmin))
+    r = np.linspace(rmin, rmax, int(100 * (rmax - rmin)))
     A0 = np.zeros((len(zs), len(r)), complex)
     for z in enumerate(zs):
         A0[z[0]] = (1 / (1 - r**2 + 2 * 1j * r * z[1]))
@@ -655,7 +655,7 @@ def transmissibility(zs=np.array([0.05, 0.1, 0.25, 0.5, -0.75]),
     """
     if not isinstance(zs, list):
         zs = [zs]
-    r = np.linspace(rmin, rmax, 300 * (rmax - rmin))
+    r = np.linspace(rmin, rmax, int(300 * (rmax - rmin)))
     DT = np.zeros((len(zs), len(r)))
     for z in enumerate(zs):
         # 2.71
@@ -759,7 +759,7 @@ def rotating_unbalance(m, m0, e, zs, rmin, rmax, normalized=True):
     """
     if not isinstance(zs, list):
         zs = [zs]
-    r = np.linspace(rmin, rmax, 100 * (rmax - rmin))
+    r = np.linspace(rmin, rmax, int(100 * (rmax - rmin)))
     Xn = np.zeros((len(zs), len(r)), complex)
     for z in enumerate(zs):
         Xn[z[0]] = (r / (1 - r**2 + 2 * 1j * r * z[1]))
@@ -786,7 +786,7 @@ def rotating_unbalance(m, m0, e, zs, rmin, rmax, normalized=True):
         ax2.plot(r, -np.angle(X_z) / np.pi * 180)
 
     ax1.legend(([r'$\zeta$ = ' + (str(s)) for s in zs]))
-
+    plt.show()
     return r, Xn
 
 

--- a/vibration_toolbox/vibesystem.py
+++ b/vibration_toolbox/vibesystem.py
@@ -445,7 +445,7 @@ class VibeSystem(object):
         >>> sys = VibeSystem(M, C, K) # create the system
         >>> # plot frequency response for input and output at m0
         >>> sys.plot_freq_response(0, 0)
-        (<matplotlib.axes._...
+        (<AxesSubplot:ylabel=...
         """
         if ax0 is None or ax1 is None:
             fig, ax = plt.subplots(2)
@@ -521,7 +521,7 @@ class VibeSystem(object):
         >>> # plot frequency response for inputs at [0, 1]
         >>> # and outputs at [0, 1]
         >>> sys.plot_freq_response_grid(outs=[0, 1], inps=[0, 1])
-        array([[<matplotlib.axes._...
+        array([[<AxesSubplot:ylabel=...
         """
         if ax is None:
             fig, ax = plt.subplots(len(inps) * 2, len(outs),
@@ -593,7 +593,7 @@ class VibeSystem(object):
         >>> F1 = np.zeros((len(t), 2))
         >>> F1[:, 1] = 1000*np.sin(40*t) # force applied on m1
         >>> sys.plot_time_response(F1, t)
-        array([<matplotlib.axes...
+        array([<AxesSubplot:ylabel=...
         """
         if ax is None:
             fig, axs = plt.subplots(self.lti.outputs, 1, sharex=True)


### PR DESCRIPTION
I tried to solve the error in travis from the previous closed PR. So this PR is same as previous with focus on python 3.6 rather than python 3.5.

This PR mainly solves float interpretation of float as integer in the following functions:

- vtb.rotating_unbalance()
- vtb.transmissibility_i()
- vtb.steady_state_response()

It also show plot of `time_plot()` directly (by uncommet plt.show()) as other functions.

To avoid the future error on Travis build, I would like to suggest using only python 3.6 to build on travis (or maybe adding python 3.8 as an alternative..?)